### PR TITLE
porting code to Python3 and networkx 2.x

### DIFF
--- a/src/EMDUnifrac.py
+++ b/src/EMDUnifrac.py
@@ -21,19 +21,19 @@ def main(argv):
 	try:
 		opts, args = getopt.getopt(argv, "g:r:h", ["GroundTruth=", "Reconstruction="])
 	except getopt.GetoptError:
-		print 'Files must be in the Bioboxes profiling format: https://github.com/bioboxes/rfc/tree/master/data-format'
-		print 'Call using: python EMDUnifrac.py -g <GroundTruth.cami> -r <Reconstruction.cami>'
+		print('Files must be in the Bioboxes profiling format: https://github.com/bioboxes/rfc/tree/master/data-format')
+		print('Call using: python EMDUnifrac.py -g <GroundTruth.cami> -r <Reconstruction.cami>')
 		sys.exit(2)
 	for opt, arg in opts:
 		if opt == '-h':
-			print 'Files must be in the Bioboxes profiling format: https://github.com/bioboxes/rfc/tree/master/data-format'
-			print 'Call using: python EMDUnifrac.py -g <GroundTruth.cami> -r <Reconstruction.cami>'
+			print('Files must be in the Bioboxes profiling format: https://github.com/bioboxes/rfc/tree/master/data-format')
+			print('Call using: python EMDUnifrac.py -g <GroundTruth.cami> -r <Reconstruction.cami>')
 			sys.exit(2)
 		elif opt in ("-g", "--GroundTruth"):
 			input_file1 = arg
 		elif opt in ("-r", "--Reconstruction"):
 			input_file2 = arg
-	print emd_unifrac(input_file1, input_file2)
+	print(emd_unifrac(input_file1, input_file2))
 
 
 def read_taxonomy_file(file_path):
@@ -97,11 +97,11 @@ def emd_unifrac(file_path_truth, file_path_query):
 			network_graph.add_edge(parent_id, tax_ids[i], weight=branch_len)
 			network_graph_directed.add_edge(parent_id, tax_ids[i], weight=branch_len)
 			# break  # you found the parent, so stop traversing up the taxpath
-	nodes = network_graph.nodes()
+	nodes = list(network_graph.nodes())
 	node_distance_matrix = numpy.zeros([len(nodes), len(nodes)], dtype=numpy.int8)
 
 	# Compute all pairwise distances
-	dist_dict = networkx.all_pairs_dijkstra_path_length(network_graph)
+	dist_dict = dict(networkx.all_pairs_dijkstra_path_length(network_graph))
 	lookup = {}
 	for i, elem in enumerate(nodes):
 		lookup[elem] = i

--- a/src/ProfilingMetrics.py
+++ b/src/ProfilingMetrics.py
@@ -24,11 +24,11 @@ def main(argv):
 			argv, "g:r:o:e:n:c:h",
 			["GroundTruth=", "Reconstruction=", "Output=", "Epsilon=", "Normalize=","CAMIformat="])
 	except getopt.GetoptError:
-		print 'Call using: python ProfilingMetrics.py -g <GroundTruth.profile> -r <Reconstruction.profile> -o <Output.txt> -e epsilon -n <normalize(y/n)> [-c <CAMIformat(y/n)>]'
+		print('Call using: python ProfilingMetrics.py -g <GroundTruth.profile> -r <Reconstruction.profile> -o <Output.txt> -e epsilon -n <normalize(y/n)> [-c <CAMIformat(y/n)>]')
 		sys.exit(2)
 	for opt, arg in opts:
 		if opt == '-h':
-			print 'Call using: python ProfilingMetrics.py -g <GroundTruth.profile> -r <Reconstruction.profile> -o <Output.txt> -e epsilon -n <normalize(y/n)> [-c <CAMIformat(y/n)>]'
+			print('Call using: python ProfilingMetrics.py -g <GroundTruth.profile> -r <Reconstruction.profile> -o <Output.txt> -e epsilon -n <normalize(y/n)> [-c <CAMIformat(y/n)>]')
 			sys.exit(2)
 		elif opt in ("-g", "--GroundTruth"):
 			file_path_truth = arg
@@ -46,8 +46,8 @@ def main(argv):
 
 
 def read_taxonomy_file(file_path, epsilon=None):
-	assert isinstance(file_path, basestring)
-	assert epsilon is None or isinstance(epsilon, (float, int, long))
+	assert isinstance(file_path, str)
+	assert epsilon is None or isinstance(epsilon, (float, int))
 	tax_path = list()
 	tax_ids = list()
 	weights = dict()
@@ -77,10 +77,10 @@ def read_taxonomy_file(file_path, epsilon=None):
 
 
 def calc_metrics(file_path_truth, file_path_recon, file_path_output, epsilon=None, normalize=True,camioutput=False):
-	assert isinstance(file_path_truth, basestring), file_path_truth
-	assert isinstance(file_path_recon, basestring), file_path_recon
-	assert isinstance(file_path_output, basestring), file_path_output
-	assert epsilon is None or isinstance(epsilon, (float, int, long)), epsilon
+	assert isinstance(file_path_truth, str), file_path_truth
+	assert isinstance(file_path_recon, str), file_path_recon
+	assert isinstance(file_path_output, str), file_path_output
+	assert epsilon is None or isinstance(epsilon, (float, int)), epsilon
 	assert isinstance(normalize, bool), normalize
 
 	# read taxonomic profiles


### PR DESCRIPTION
I am adding a new profiler to our existing CAMI set. Since we don't have a docker environment, I am running all natively in an Python 3.5 environment.
Here are the few changes necessary to port this code over to py3 and a more recent networkX version.

@pbelmann would it make sense to update the Docker image?